### PR TITLE
Allow unauthenticated connections, display names can be used with from/to addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,8 @@ await client.connectTLS({
 
 #### Use in Gmail
 ```ts
-await client.connect({
-  tls: true,
-  host: "smtp.gamil.com",
+await client.connectTLS({
+  host: "smtp.gmail.com",
   port: 465,
   username: "your username",
   password: "your password",

--- a/config.ts
+++ b/config.ts
@@ -1,9 +1,12 @@
 export interface ConnectConfig {
   hostname: string;
   port?: number;
+}
+
+export type ConnectConfigWithAuthentication = ConnectConfig & {
   username: string;
   password: string;
-}
+};
 
 export interface SendConfig {
   to: string;

--- a/smtp.ts
+++ b/smtp.ts
@@ -57,7 +57,7 @@ export class SmtpClient {
 
     await this.writeCmd("Subject: ", config.subject);
     await this.writeCmd("From: ", config.from);
-    await this.writeCmd("To: ", `<${config.from}>`);
+    await this.writeCmd("To: ", `<${config.to}>`);
     await this.writeCmd("Date: ", new Date().toString());
 
     await this.writeCmd("MIME-Version: 1.0");

--- a/tests/test_parse.ts
+++ b/tests/test_parse.ts
@@ -1,0 +1,15 @@
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+const { test } = Deno;
+
+function parseAddress(email: string): [string, string] {
+  const m = email.match(/(.*)\s<(.*)>/);
+  return m?.length === 3 ? [`<${m[2]}>`, email] : [`<${email}>`, `<${email}>`];
+}
+
+test("parse adresses (MAIL FROM, RCPT TO and DATA commands)", () => {
+  const [e1, e2] = parseAddress("Deno Land <root@deno.land>");
+  assertEquals([e1, e2], ["<root@deno.land>", "Deno Land <root@deno.land>"]);
+
+  const [e3, e4] = parseAddress("root@deno.land");
+  assertEquals([e3, e4], ["<root@deno.land>", "<root@deno.land>"]);
+});


### PR DESCRIPTION
Hi,

The SMTP server I'm using at work does not allow authenticated connections (duh, I know 🙄). It returns a `504: 5.7.4 Unrecognized authentication type`.

Have a good one!