### PR TITLE
switch quoted-printable Content-Transfer-Encoding for 7bit

### DIFF
--- a/smtp.ts
+++ b/smtp.ts
@@ -65,7 +65,7 @@ export class SmtpClient {
 
     await this.writeCmd("MIME-Version: 1.0");
     await this.writeCmd("Content-Type: text/html;charset=utf-8");
-    await this.writeCmd("Content-Transfer-Encoding: quoted-printable");
+    await this.writeCmd("Content-Transfer-Encoding: 7bit");
     await this.writeCmd(config.content, "\r\n.\r\n");
 
     this.assertCode(await this.readCmd(), CommandCode.OK);


### PR DESCRIPTION
Hello sir

first thanks for your contribution to deno runtime.
I noticed my emails sent in html with characters containing equal = would be broken and transformed (=3D) differently
depending on the webmail platform.
As i recalled html emails used to work with node mailer i went there
https://github.com/nodemailer/nodemailer/blob/master/lib/mime-node/index.js#L448
and tried 7bit which for the moment i use to solve this problem.
There are probably regression or at least missing part somewhere else this little modif implies

hope to hear from you