### PR TITLE
(feat) Add support for options in the SMTP client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Deno
         uses: denolib/setup-deno@master
         with:
-          deno-version: 1.1.3
+          deno-version: 1.2.2
 
       - name: Test
         env:

--- a/README.md
+++ b/README.md
@@ -59,3 +59,16 @@ await client.send({
 
 await client.close();
 ```
+
+### Configuring your client
+
+You can pass options to your client through the `SmtpClient` constructor.
+
+```ts
+import { SmtpClient } from "https://deno.land/x/smtp/mod.ts";
+
+//Defaults
+const client = new SmtpClient({
+  content_encoding: "quoted-printable", // 7bit, 8bit, base64, binary, quoted-printable
+});
+```

--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,5 @@
 export {
   BufReader,
   BufWriter,
-} from "https://deno.land/std@v0.60.0/io/bufio.ts";
-export { TextProtoReader } from "https://deno.land/std@v0.60.0/textproto/mod.ts";
+} from "https://deno.land/std@v0.63.0/io/bufio.ts";
+export { TextProtoReader } from "https://deno.land/std@v0.63.0/textproto/mod.ts";

--- a/smtp.ts
+++ b/smtp.ts
@@ -13,15 +13,43 @@ interface Command {
   args: string;
 }
 
+enum ContentTransferEncoding {
+  "7bit" = "7bit",
+  "8bit" = "8bit",
+  "base64" = "base64",
+  "binary" = "binary",
+  "quoted-printable" = "quoted-printable",
+}
+
+interface SmtpClientOptions {
+  content_encoding?:
+    | "7bit"
+    | "8bit"
+    | "base64"
+    | "binary"
+    | "quoted-printable";
+}
+
 export class SmtpClient {
   private _conn: Deno.Conn | null;
   private _reader: TextProtoReader | null;
   private _writer: BufWriter | null;
+  private _content_encoding: ContentTransferEncoding;
 
-  constructor() {
+  constructor({
+    content_encoding = ContentTransferEncoding["quoted-printable"],
+  }: SmtpClientOptions = {}) {
     this._conn = null;
     this._reader = null;
     this._writer = null;
+
+    const _content_encoding = String(content_encoding).toLowerCase();
+    if (!(_content_encoding in ContentTransferEncoding)) {
+      throw new Error(
+        `${JSON.stringify(content_encoding)} is not a valid content encoding`,
+      );
+    }
+    this._content_encoding = _content_encoding as ContentTransferEncoding;
   }
 
   async connect(config: ConnectConfig) {
@@ -65,7 +93,7 @@ export class SmtpClient {
 
     await this.writeCmd("MIME-Version: 1.0");
     await this.writeCmd("Content-Type: text/html;charset=utf-8");
-    await this.writeCmd("Content-Transfer-Encoding: quoted-printable");
+    await this.writeCmd(`Content-Transfer-Encoding: ${this._content_encoding}`);
     await this.writeCmd(config.content, "\r\n.\r\n");
 
     this.assertCode(await this.readCmd(), CommandCode.OK);

--- a/tests/test_parse.ts
+++ b/tests/test_parse.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.60.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.63.0/testing/asserts.ts";
 
 function parseAddress(email: string): [string, string] {
   const m = email.match(/(.*)\s<(.*)>/);


### PR DESCRIPTION
* This is a non breaking change
* This is intended to work with both JavaScript and TypeScript (argument check)
* This won't alter the defaults previously set (Content-Transfer-Encoding = 'quoted-printable') unless explictly told so in the options object
* This adds documentation for the options argument


### Disclaimer
It was made verbose (interface and enum) on purpose so it could provide autocomplete capabilities for code editors