### PR TITLE
AlternativeBoundary implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Deno
         uses: denolib/setup-deno@master
         with:
-          deno-version: 1.4.4
+          deno-version: 1.6.1
 
       - name: Test
         env:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ await client.send({
   from: "mailaddress@163.com",
   to: "to-address@xx.com",
   subject: "Mail Title",
-  content: "Mail Content，maybe HTML",
+  content: "Mail Content",
+  html: "<a href='https://github.com'>Github</a>",
 });
 
 await client.close();

--- a/config.ts
+++ b/config.ts
@@ -13,6 +13,7 @@ interface SendConfig {
   from: string;
   subject: string;
   content: string;
+  html?: string;
 }
 
-export type { ConnectConfigWithAuthentication, ConnectConfig, SendConfig }
+export type { ConnectConfigWithAuthentication, ConnectConfig, SendConfig };

--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,6 @@
 export {
   BufReader,
-  BufWriter,
-} from "https://deno.land/std@0.73.0/io/bufio.ts";
-export { TextProtoReader } from "https://deno.land/std@0.73.0/textproto/mod.ts";
+  BufWriter
+} from "https://deno.land/std@0.81.0/io/bufio.ts";
+export { TextProtoReader } from "https://deno.land/std@0.81.0/textproto/mod.ts";
+

--- a/test.ts
+++ b/test.ts
@@ -21,7 +21,8 @@ await client.send({
   from: MAIL_USER,
   to: MAIL_TO_USER,
   subject: "Deno Smtp build Success" + Math.random() * 1000,
-  content: `
+  content: "plain text email",
+  html: `
   <!DOCTYPE html>
       <html lang="en">
         <head>

--- a/tests/test_parse.ts
+++ b/tests/test_parse.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.63.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.81.0/testing/asserts.ts";
 
 function parseAddress(email: string): [string, string] {
   const m = email.match(/(.*)\s<(.*)>/);


### PR DESCRIPTION
The emails which arrive on certain mailboxes are not correctly standardized and are therefore interpreted as plain text emails, Gmail is one of the examples

So I added AlternativeBoundary support for emails as additional feature to not break the already existing code of some projects using deno smtp

Hoping to have helped 😊