### PR TITLE
Made content property optional

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -8,13 +8,26 @@ interface ConnectConfigWithAuthentication extends ConnectConfig {
   password: string;
 }
 
-interface SendConfig {
+interface SendAbstract {
   to: string;
   from: string;
   date?: string;
   subject: string;
-  content: string;
-  html?: string;
 }
+
+interface SendBoth extends SendAbstract {
+  html: string;
+  content: string;
+}
+
+interface SendHtml extends SendAbstract {
+  html: string;
+}
+
+interface SendContent extends SendAbstract {
+  content: string;
+}
+
+type SendConfig = SendBoth | SendHtml | SendContent;
 
 export type { ConnectConfig, ConnectConfigWithAuthentication, SendConfig };

--- a/smtp.ts
+++ b/smtp.ts
@@ -92,14 +92,18 @@ export class SmtpClient {
     await this.writeCmd("To: ", toData);
     await this.writeCmd("Date: ", date);
 
-    if (config.html) {
+    if ("html" in config) {
       await this.writeCmd(
         "Content-Type: multipart/alternative; boundary=AlternativeBoundary",
         "\r\n",
       );
+
+      const content = "content" in config ? config.content : "Please use a mail client that supports HTML";
+      
       await this.writeCmd("--AlternativeBoundary");
       await this.writeCmd('Content-Type: text/plain; charset="utf-8"', "\r\n");
-      await this.writeCmd(config.content, "\r\n");
+      await this.writeCmd(content, "\r\n");
+
       await this.writeCmd("--AlternativeBoundary");
       await this.writeCmd('Content-Type: text/html; charset="utf-8"', "\r\n");
       await this.writeCmd(config.html, "\r\n.\r\n");


### PR DESCRIPTION
Now the user can just send an email with either `html` and `content`, `html` or `content`

If only HTML is provided the email will fall back on a warning message about using a mail client that supports HTML